### PR TITLE
Clean readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ This is a Ruby version of the Gilded Rose Kata, found
 [here](http://iamnotmyself.com/2011/02/13/refactor-this-the-gilded-rose-kata/).
 
 This is a refactoring kata, so you will be starting with a legacy
-code base.  To work the Kata, clone this git repository and checkout
-the tag 'start-here'. Read the description below for the "rules"
-involving this kata.
+code base.  To work the Kata, clone this git repository.
+Read the description below for the "rules" involving this kata.
 
 ## Changes from the original
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Ruby version of the Gilded Rose Kata, found
 [here](http://iamnotmyself.com/2011/02/13/refactor-this-the-gilded-rose-kata/).
 
-This is a refactorying kata, so you will be starting with a legacy
+This is a refactoring kata, so you will be starting with a legacy
 code base.  To work the Kata, clone this git repository and checkout
 the tag 'start-here'. Read the description below for the "rules"
 involving this kata.


### PR DESCRIPTION
As I was reading the instructions for this Kata, I saw some that there were minor details in the readme that needed fixing:

1. A small typo of `refactorying` was corrected to `refactoring`.
2. An extra instruction of checking out to the `start-here` tag was removed, because `master` better reflects the kata's initial state. It contains commits from other contributors to make the kata easier to setup.